### PR TITLE
Fixed Spotify login button styling

### DIFF
--- a/src/home/static/homepage.css
+++ b/src/home/static/homepage.css
@@ -282,6 +282,36 @@ body {
   background: #f5f5f5;
 }
 
+.spotify-button {
+          display: inline-flex;
+          align-items: center;
+          gap: 12px;
+          background: #1DB954;
+          color: white;
+          padding: 15px 35px;
+          border-radius: 50px;
+          text-decoration: none;
+          font-weight: 600;
+          font-size: 1.1rem;
+          transition: all 0.3s ease;
+          box-shadow: 0 4px 15px rgba(29, 185, 84, 0.3);
+      }
+
+      .spotify-button:hover {
+          background: #1ed760;
+          transform: translateY(-2px);
+          box-shadow: 0 6px 20px rgba(29, 185, 84, 0.4);
+      }
+
+      .spotify-button:active {
+          transform: translateY(0);
+      }
+
+      .spotify-icon {
+          width: 30px;
+          height: 30px;
+      }
+
 @media (max-width: 900px) {
   .playlists-grid {
     grid-template-columns: 1fr;
@@ -316,34 +346,4 @@ body {
   .search-container {
     flex-direction: column;
   }
-
-  .spotify-button {
-          display: inline-flex;
-          align-items: center;
-          gap: 12px;
-          background: #1DB954;
-          color: white;
-          padding: 15px 35px;
-          border-radius: 50px;
-          text-decoration: none;
-          font-weight: 600;
-          font-size: 1.1rem;
-          transition: all 0.3s ease;
-          box-shadow: 0 4px 15px rgba(29, 185, 84, 0.3);
-      }
-
-      .spotify-button:hover {
-          background: #1ed760;
-          transform: translateY(-2px);
-          box-shadow: 0 6px 20px rgba(29, 185, 84, 0.4);
-      }
-
-      .spotify-button:active {
-          transform: translateY(0);
-      }
-
-      .spotify-icon {
-          width: 30px;
-          height: 30px;
-      }
 }

--- a/src/home/templates/home/index.html
+++ b/src/home/templates/home/index.html
@@ -22,7 +22,7 @@
 
   <main class="main-content">
     <section class="playlists-section">
-      <h2>Top Playlists - Likes</h2>
+      <h2>Top Playlists</h2>
 
       <div class="playlists-grid">
         {% for playlist in playlists %}


### PR DESCRIPTION
Didn't realize the spotify-button css only triggered for <900px-width screens, moved styling outside of @media brackets