### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/src/dashboard/templates/dashboard/dashboard.html
+++ b/src/dashboard/templates/dashboard/dashboard.html
@@ -482,6 +482,16 @@
             }
         };
 
+        // Helper to escape HTML special characters in a string.
+        const escapeHtml = (unsafe) => {
+            return String(unsafe)
+                .replace(/&/g, "&amp;")
+                .replace(/</g, "&lt;")
+                .replace(/>/g, "&gt;")
+                .replace(/"/g, "&quot;")
+                .replace(/'/g, "&#039;");
+        };
+
         const renderGenreBreakdown = (entries) => {
             if (!genreList) {
                 return;
@@ -493,7 +503,7 @@
             genreList.innerHTML = entries
                 .map(
                     (entry) =>
-                        `<li><span>${entry.genre}</span><span>${entry.percentage}%</span></li>`
+                        `<li><span>${escapeHtml(entry.genre)}</span><span>${escapeHtml(entry.percentage)}%</span></li>`
                 )
                 .join('');
         };


### PR DESCRIPTION
Potential fix for [https://github.com/calebc1800/AIPlaylistGenerator/security/code-scanning/5](https://github.com/calebc1800/AIPlaylistGenerator/security/code-scanning/5)

To fix this vulnerability, all data interpolated into HTML must be properly escaped for the HTML context. This means that before interpolating `entry.genre` and `entry.percentage`, we must HTML-escape their string values.

- General fix: Use an escaping function to convert special HTML characters (`& < > " ' /`) to their respective HTML entities before inserting into `.innerHTML`.
- Best way in this context:  
    1. Implement a small JavaScript escaping utility (e.g., `escapeHtml`), or use a well-known, minimal escaping function inline.
    2. Apply this escape to both `entry.genre` and `entry.percentage` in the mapping function (line 496).
- Minimal code changes:  
    - Add an `escapeHtml` helper in the script block (before the use in `renderGenreBreakdown`).
    - Update the `.map()` in `renderGenreBreakdown` to escape both dynamic values.
- No external libraries or complex imports needed; a local function suffices.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
