### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ '**' ]
   pull_request:
-    branches: 
+    branches:
     - main
 
 jobs:
@@ -20,17 +20,17 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install openai requests python-dotenv PyGithub
-      
+
       - name: Check if AI review script exists
         id: check_script
         run: |
@@ -40,7 +40,7 @@ jobs:
             echo "script_exists=false" >> $GITHUB_OUTPUT
             echo "AI review script not found at .github/scripts/ai_review.py"
           fi
-      
+
       - name: Ensure OPENAI_API_KEY is present for same-repo PRs
         if: github.event.pull_request.head.repo.full_name == github.repository && steps.check_script.outputs.script_exists == 'true'
         env:
@@ -50,7 +50,7 @@ jobs:
             echo "ERROR: OPENAI_API_KEY secret is missing — aborting AI review."
             exit 1
           fi
-      
+
       - name: Run AI Code Review
         if: github.event.pull_request.head.repo.full_name == github.repository && steps.check_script.outputs.script_exists == 'true'
         env:
@@ -63,12 +63,12 @@ jobs:
         run: |
           echo "🧠 Running AI Code Review..."
           python .github/scripts/ai_review.py
-      
+
       - name: Skip AI Review for forked PRs
         if: github.event.pull_request.head.repo.full_name != github.repository
         run: |
           echo "AI review skipped: this pull request originates from a fork and repository secrets are not available."
-      
+
       - name: Skip AI Review - script not found
         if: steps.check_script.outputs.script_exists == 'false'
         run: |
@@ -77,15 +77,17 @@ jobs:
   tests:
     name: Run Django Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -95,7 +97,7 @@ jobs:
             echo "requirements.txt not found, installing basic test dependencies"
             pip install django pytest pytest-cov pytest-django
           fi
-      
+
       - name: Run Tests with Coverage
         env:
           DJANGO_SETTINGS_MODULE: aiplaylist.settings
@@ -104,14 +106,14 @@ jobs:
           export PYTHONPATH="${PYTHONPATH}:${{ github.workspace }}/src"
           echo "PYTHONPATH set to: $PYTHONPATH"
           python -c "import aiplaylist; print('✅ Django project imported successfully')"
-          
+
           if command -v pytest &> /dev/null; then
             pytest --cov=. --cov-report=term-missing --cov-fail-under=80 -v
           else
             echo "pytest not available, running Django tests directly"
             python src/manage.py test
           fi
-  
+
   pylint:
     name: Pylint
     runs-on: ubuntu-latest
@@ -120,12 +122,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      
+
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      
+
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -135,7 +137,7 @@ jobs:
             echo "requirements.txt not found, installing basic test dependencies"
             pip install django pylint pylint-django
           fi
-      
+
       - name: Run Pylint Tests with Coverage
         env:
           DJANGO_SETTINGS_MODULE: aiplaylist.settings
@@ -144,7 +146,7 @@ jobs:
           export PYTHONPATH="${PYTHONPATH}:${{ github.workspace }}/src"
           echo "PYTHONPATH set to: $PYTHONPATH"
           python -c "import aiplaylist; print('✅ Django project imported successfully')"
-          
+
           if command -v pylint &> /dev/null; then
             pylint --load-plugins pylint_django --django-settings-module=src.aiplaylist.settings --fail-under=8.0 src/
           else


### PR DESCRIPTION
Potential fix for [https://github.com/calebc1800/AIPlaylistGenerator/security/code-scanning/2](https://github.com/calebc1800/AIPlaylistGenerator/security/code-scanning/2)

To fix the problem, we should explicitly set the minimal necessary permissions for the `pylint` job in `.github/workflows/ci.yml`. Since this job only checks out code and runs pylint, it only needs read access to the repository's contents. Therefore, we should add a `permissions:` block with `contents: read` at the same indentation level as `runs-on:` within the `pylint` job’s configuration, just like the `ai_code_review` job. The fix should be made directly within the `pylint` job configuration (near line 117 after `runs-on: ubuntu-latest`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
